### PR TITLE
Add startup scripts for Linux, macOS and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv/
 temp/
 __pycache__/
 NewSamples/

--- a/frontend/.vite/deps/package-lock.json
+++ b/frontend/.vite/deps/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "deps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/startup.bat
+++ b/startup.bat
@@ -1,0 +1,6 @@
+@ECHO OFF
+FOR /f %%p in ('where python') do SET PYTHONPATH=%%p
+START %PYTHONPATH% backend/server.py
+START %PYTHONPATH% backend/main_backend.py
+CD frontend
+START npm run dev

--- a/startup.bat
+++ b/startup.bat
@@ -1,6 +1,5 @@
 @ECHO OFF
-FOR /f %%p in ('where python') do SET PYTHONPATH=%%p
-START %PYTHONPATH% backend/server.py
-START %PYTHONPATH% backend/main_backend.py
+START python backend/server.py
+START python backend/main_backend.py
 CD frontend
 START npm run dev

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+/bin/sh -ec 'python backend/main_backend.py'
+/bin/sh -ec 'python backend/server.py'
+/bin/sh -ec 'cd frontend && npm run dev'


### PR DESCRIPTION
.bat file for Windows and .sh for macOS and Linux.

Issues:
> If python is not in path (e.g. if its py, python3) it won't work. 